### PR TITLE
Fixed LWC creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,7 @@
     "reverse-string": "0.0.6",
     "sequin": "^0.1.1",
     "typescript": "^2.9.2",
+    "vsce": "^1.55.0",
     "vscode": "^1.1.18",
     "xml2js": "^0.4.19",
     "zip": "^1.2.0"

--- a/src/commands/createLwc.ts
+++ b/src/commands/createLwc.ts
@@ -9,6 +9,9 @@ export default function createLwc(context: vscode.ExtensionContext) {
     // Here is replaceSrc possiblity
     return configuration().then(config => {
       lwcsPath = `${vscode.window.forceCode.workspaceRoot}${path.sep}lwc`;
+      if (!fs.existsSync(lwcsPath)) {
+        fs.mkdirSync(lwcsPath)
+      }
       if (fs.statSync(lwcsPath).isDirectory()) {
         return userFileNameSelection().then(lwcname => {
           return generateFiles(lwcname, config)
@@ -35,6 +38,7 @@ export default function createLwc(context: vscode.ExtensionContext) {
               if (lwcname.indexOf(' ') > -1) {
                 lwcname = lwcname.replace(' ', '');
               }
+              lwcname = lwcname.charAt(0).toLowerCase() + lwcname.slice(1)
               return lwcname;
           }
           return undefined;


### PR DESCRIPTION
On LWC creation it checks whether the folder /src/lwc exists or not and it gets created if it doesn't.
Also fixed the creation of the component itself, if it starts with an uppercase letter it doesn't get deployed, so it just lowercases the first letter of the name